### PR TITLE
[TASK] Fix composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         ]
     },
     "replace": {
-        "mjml": "self.version",
         "typo3-ter/mjml": "self.version"
     },
     "extra": {


### PR DESCRIPTION
Deprecation warning: replace.mjml is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.